### PR TITLE
compilation warnings + removed points outside rectangle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,16 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-local-typedefs)
 endif()
+
+add_definitions("-DBOOST_ALLOW_DEPRECATED_HEADERS")
+add_definitions("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(message_filters REQUIRED)
-find_package(pcl_msgs REQUIRED)
+find_package(pcl_conversions REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -23,15 +25,14 @@ find_package(Eigen3 REQUIRED)
 find_package(lanelet2_core REQUIRED)
 find_package(lanelet2_io REQUIRED)
 find_package(lanelet2_projection REQUIRED)
-find_package(PCL 1.3 REQUIRED)
 
-include_directories(${pcl_msgs_INCLUDE_DIRS})
-include_directories(${message_filters_INCLUDE_DIRS})
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
+find_package(PCL REQUIRED)
 
 file(MAKE_DIRECTORY lib)
+
+include_directories(SYSTEM
+  ${PCL_INCLUDE_DIRS}
+)
 
 ####################################
 # file_in
@@ -184,8 +185,8 @@ target_include_directories(messages
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/flexmap_fusion/messages>
     $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(messages message_conversion visualization ${PCL_LIBRARIES} ${message_filters_LIBRARIES} ${pcl_msgs_LIBRARIES})
-ament_target_dependencies(messages rclcpp geometry_msgs visualization_msgs lanelet2_core lanelet2_io lanelet2_projection)
+target_link_libraries(messages message_conversion visualization ${PCL_LIBRARIES})
+ament_target_dependencies(messages rclcpp geometry_msgs visualization_msgs pcl_conversions lanelet2_core lanelet2_io lanelet2_projection)
 
 ####################################
 # analysis

--- a/include/flexmap_fusion/file_io/file_in.hpp
+++ b/include/flexmap_fusion/file_io/file_in.hpp
@@ -27,7 +27,7 @@
 #include <lanelet2_io/Io.h>
 #include <lanelet2_projection/UTM.h>
 #include <pcl/io/pcd_io.h>
-
+#include <pcl/point_types.h>
 
 #include <string>
 #include <vector>

--- a/include/flexmap_fusion/file_io/file_out.hpp
+++ b/include/flexmap_fusion/file_io/file_out.hpp
@@ -25,6 +25,7 @@
 #include <lanelet2_io/Io.h>
 #include <lanelet2_projection/UTM.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
 
 #include <string>
 #include <vector>

--- a/include/flexmap_fusion/map_transformation/align.hpp
+++ b/include/flexmap_fusion/map_transformation/align.hpp
@@ -30,7 +30,6 @@
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LineString.h>
 #include <lanelet2_core/primitives/Point.h>
-#include <pcl/io/pcd_io.h>
 
 #include <string>
 #include <vector>

--- a/include/flexmap_fusion/map_transformation/rubber_sheeting.hpp
+++ b/include/flexmap_fusion/map_transformation/rubber_sheeting.hpp
@@ -36,6 +36,8 @@
 #include <lanelet2_core/primitives/LineString.h>
 #include <lanelet2_core/primitives/Point.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl/filters/extract_indices.h>
 
 #include <string>
 #include <vector>

--- a/src/conflation/matching.cpp
+++ b/src/conflation/matching.cpp
@@ -692,7 +692,7 @@ void cmatching::extend_ref_pline(
     lanelet::LineStrings3d ls_angles;
     lanelet::LineString3d pline_seg = (dir == 1) ? pline.back() : pline.front();
     // Calculate angle between potential new segment and current pline segment
-    for (const auto ls_ : connected) {
+    for (const auto & ls_ : connected) {
       if (!used_Id(ids, ls_)) {
         angles.push_back(std::abs(angle_segment(pline_seg, ls_, false)));
         ls_angles.push_back(ls_);

--- a/src/file_io/file_in.cpp
+++ b/src/file_io/file_in.cpp
@@ -85,7 +85,7 @@ bool cfile_in::read_traj_GPS_from_file(
     orig_lon = traj_GPS[0].lon;
   }
 
-  std::cout << "OUTPUT: " << orig_lat << " " << orig_lon << std::endl;
+  std::cout << "\033[33mMap origin: " << orig_lat << " " << orig_lon << "\033[0m" << std::endl;
 
   // Calculate boundaries of map piece
   double max_lat, max_lon, min_lat, min_lon;

--- a/src/map_transformation/align.cpp
+++ b/src/map_transformation/align.cpp
@@ -163,9 +163,9 @@ void calign::get_intersection_nodes(
   int is_intersection = 0;
 
   // Iterate throughh ls and check Ids
-  for (const auto ls : osm_ls) {
-    for (const auto point : ls) {
-      for (const auto ls_pt : ls_pts) {
+  for (const auto & ls : osm_ls) {
+    for (const auto & point : ls) {
+      for (const auto & ls_pt : ls_pts) {
         if (point.id() == ls_pt.id()) {
           is_intersection = 1;
         }


### PR DESCRIPTION
- adjusted cmakelists and header files so that no harmless warnings are shown during compilation which hinder further development by filling compiler messages
- increased buffer around trajectories during rubber-sheeting to 10% instead of 5%
- remove points that are not within the rectangle during rubber-sheeting